### PR TITLE
SK-549 Removal of Grace Period of 5 mins

### DIFF
--- a/skyflow/client/token_utils.go
+++ b/skyflow/client/token_utils.go
@@ -1,5 +1,5 @@
 /*
-	Copyright (c) 2022 Skyflow, Inc.
+Copyright (c) 2022 Skyflow, Inc.
 */
 package client
 
@@ -48,6 +48,5 @@ func isTokenExpired(tokenString string) bool {
 	}
 	var expiryTime = claims.ExpiresAt
 	currentTime := time.Now()
-	currentTime = currentTime.Add(time.Duration(+5) * time.Minute)
 	return expiryTime.Before(currentTime)
 }


### PR DESCRIPTION
## Removal of Grace Period of 5 mins

- Removed 5 mins of grace period for cache refresh of bearer token
- Issue [SK-549](https://skyflow.atlassian.net/browse/SK-549)

[SK-549]: https://skyflow.atlassian.net/browse/SK-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ