### PR TITLE
SK-1905 include request ids in response for continue on error partial failure cases

### DIFF
--- a/client/service_test.go
+++ b/client/service_test.go
@@ -413,7 +413,7 @@ var _ = Describe("Vault controller Test cases", func() {
 			})
 			It("should return detokenized data with errors", func() {
 				response := make(map[string]interface{})
-				mockJSONResponse := `{"error":{"grpc_code":5,"http_code":404,"message":"Detokenize failed. All tokens are invalid. Specify valid tokens.","http_status":"Not Found","details":[]}}`
+				mockJSONResponse := `{"error":{"grpc_code":5,"http_code":404,"X-Request-Id": "123455","message":"Detokenize failed. All tokens are invalid. Specify valid tokens.","http_status":"Not Found","details":[]}}`
 				_ = json.Unmarshal([]byte(mockJSONResponse), &response)
 				// Set the mock server URL in the controller's client
 				ts := setupMockServer(response, "err", "/vaults/v1/vaults/")
@@ -433,6 +433,33 @@ var _ = Describe("Vault controller Test cases", func() {
 				Expect(err1).To(BeNil())
 				res, err := service.Detokenize(ctx, request, options) // Validate the response
 				Expect(err).ToNot(BeNil())
+				Expect(err.GetRequestId()).To(Equal("123456"))
+				Expect(res).To(BeNil())
+			})
+			It("should return detokenized data with errors when continue on error is false", func() {
+				response := make(map[string]interface{})
+				options.ContinueOnError = false
+				mockJSONResponse := `{"error":{"grpc_code":5,"http_code":404,"x-request-Id": "123455","message":"Detokenize failed. All tokens are invalid. Specify valid tokens.","http_status":"Not Found","details":[]}}`
+				_ = json.Unmarshal([]byte(mockJSONResponse), &response)
+				// Set the mock server URL in the controller's client
+				ts := setupMockServer(response, "err", "/vaults/v1/vaults/")
+
+				CreateRequestClientFunc = func(v *VaultController) *skyflowError.SkyflowError {
+					configuration := vaultapi2.NewConfiguration()
+					configuration.AddDefaultHeader("Authorization", "Bearer token")
+					configuration.AddDefaultHeader("Content-Type", "application/json")
+					configuration.Servers[0].URL = ts.URL + "/vaults"
+					apiClient := vaultapi2.NewAPIClient(configuration)
+					v.ApiClient = *apiClient
+					return nil
+				}
+				// Call the Detokenize function
+				ctx := context.Background()
+				var service, err1 = client.Vault()
+				Expect(err1).To(BeNil())
+				res, err := service.Detokenize(ctx, request, options) // Validate the response
+				Expect(err).ToNot(BeNil())
+				Expect(err.GetRequestId()).To(Equal("123456"))
 				Expect(res).To(BeNil())
 			})
 			It("should return detokenized data with errors", func() {
@@ -1057,6 +1084,7 @@ func setupMockServer(mockResponse map[string]interface{}, status string, path st
 	// Define the handler for "/vaults/v1/vaults/"
 	mockServer.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "123456")
 		jsonData, _ := json.Marshal(mockResponse)
 		// Write the response
 		switch status {

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -13,4 +13,5 @@ const (
 	SDK_NAME               = "Skyflow Go SDK "
 	SDK_VERSION            = "v2.0.0-beta.1"
 	SDK_PREFIX             = SDK_NAME + SDK_VERSION
+	REQUEST_KEY            = "X-Request-Id"
 )

--- a/internal/vault/controller/vault_controller.go
+++ b/internal/vault/controller/vault_controller.go
@@ -387,7 +387,7 @@ func (v *VaultController) Insert(ctx context.Context, request common.InsertReque
 			if formattedRecord["skyflow_id"] != nil {
 				insertedFields = append(insertedFields, formattedRecord)
 			} else {
-				formattedRecord["requestId"] = constants.REQUEST_KEY
+				formattedRecord["requestId"] = httpsRes.Header.Get(constants.REQUEST_KEY)
 				errors = append(errors, formattedRecord)
 			}
 		}
@@ -451,7 +451,7 @@ func (v *VaultController) Detokenize(ctx context.Context, request common.Detoken
 					"Token":     record.GetToken(),
 					"Value":     record.GetValue(),
 					"Error":     record.GetError(),
-					"requestId": constants.REQUEST_KEY,
+					"requestId": httpsRes.Header.Get(constants.REQUEST_KEY),
 				}
 				errorFields = append(errorFields, er1)
 			} else {

--- a/internal/vault/controller/vault_controller.go
+++ b/internal/vault/controller/vault_controller.go
@@ -387,6 +387,7 @@ func (v *VaultController) Insert(ctx context.Context, request common.InsertReque
 			if formattedRecord["skyflow_id"] != nil {
 				insertedFields = append(insertedFields, formattedRecord)
 			} else {
+				formattedRecord["requestId"] = constants.REQUEST_KEY
 				errors = append(errors, formattedRecord)
 			}
 		}
@@ -450,6 +451,7 @@ func (v *VaultController) Detokenize(ctx context.Context, request common.Detoken
 					"Token":     record.GetToken(),
 					"Value":     record.GetValue(),
 					"Error":     record.GetError(),
+					"requestId": constants.REQUEST_KEY,
 				}
 				errorFields = append(errorFields, er1)
 			} else {


### PR DESCRIPTION
This PR addresses feedback for `Insert` and `Detokenize` methods SDK responses when `ContinueOnError` flag is `true`.
## Why
- When `ContinueOnError` flag is set to `true`, `requestId` is not present for failed requests.
- The absence of `requestId` makes it difficult to debug and troubleshoot these failed requests effectively.

## Goal
- `requestId` will be present for `detokenize` failure responses when `ContinueOnError` is `true`
- `requestId` will be present for `insert` failure responses when `ContinueOnError` is `true`

## Testing
- The changes were tested manually.
- Modified unit tests to check for presence of `requestId` in failed request responses when `ContinueOnError` is `true`