### PR TITLE
feat: add JSON object support for ctx in token generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2860,69 +2860,59 @@ func BearerTokenGenerationExample() {
 }
 ```
 ### Generate bearer tokens with context
-`Context-Aware Authorization`  embeds context values into a bearer token during its generation and so you can reference those values in your policies. This enables more flexible access controls, such as helping you track end-user identity when making API calls using service accounts, and facilitates using signed data tokens during detokenization.
+`Context-Aware Authorization` embeds context values into a bearer token during its generation so you can reference those values in your policies. This enables more flexible access controls, such as helping you track end-user identity when making API calls using service accounts, and facilitates using signed data tokens during detokenization.
+
 A service account with the `context_id` identifier generates bearer tokens containing context information, represented as a JWT claim in a Skyflow-generated bearer token. Tokens generated from such service accounts include a `context_identifier` claim, are valid for 60 minutes, and can be used to make API calls to the Data and Management APIs, depending on the service account's permissions.
 
-#### [Example](https://github.com/skyflowapi/skyflow-go/blob/v2/samples/serviceaccount/token_generation_with_context.go)
+The `Ctx` field accepts either a **string** or a **`map[string]interface{}`**:
+
+**String context** — use when your policy references a single context value:
+
 ```go
-import (
-"fmt"
-saUtil "github.com/skyflowapi/skyflow-go/v2/serviceaccount"
-"github.com/skyflowapi/skyflow-go/v2/utils/common"
-"github.com/skyflowapi/skyflow-go/v2/utils/logger"
-)
-/**
- * Example program to generate a Bearer Token using Skyflow's BearerToken utility.
- * The token is generated using two approaches:
- * 1. By providing the credentials.json file path.
- * 2. By providing the contents of credentials.json as a string.
- */
+res, err := serviceaccount.GenerateBearerToken(filePath, common.BearerTokenOptions{
+    Ctx: "user_12345",
+})
+```
 
-func BearerTokenGenerationWithContextExample() {
-    // Variable to store the generated Bearer Token
-    var bearerToken = "";
+**JSON object context** — use when your policy needs multiple context values for conditional data access. Each key in the map maps to a Skyflow CEL policy variable under `request.context.*`:
 
-    // Approach 1: Generate Bearer Token by specifying the path to the credentials.json file
-    // Replace <YOUR_CREDENTIALS_FILE_PATH> with the full path to your credentials.json file
-    var filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
+```go
+ctxMap := map[string]interface{}{
+    "role":       "admin",
+    "department": "finance",
+    "user_id":    "user_12345",
+}
+res, err := serviceaccount.GenerateBearerToken(filePath, common.BearerTokenOptions{
+    Ctx: ctxMap,
+})
+```
 
-    // Create a BearerToken using the file path
-    res, err := saUtil.GenerateBearerToken(filePath, // Set credentials using a File object
-        common.BearerTokenOptions{
-	        LogLevel: logger.DEBUG, 
-	        Ctx: "<CONTEXT>" // Set context string (example: "abc")
-        })
+With the map above, your Skyflow policies can reference `request.context.role`, `request.context.department`, and `request.context.user_id` to make conditional access decisions.
 
-    if err != nil {
-        // Handle exceptions specific to Skyflow operations
-        fmt.Println("errors:", *err)
-    } else {
-        // Print the generated Bearer Token to the console
-        bearerToken = res.AccessToken
-        fmt.Println("Token", res.AccessToken)
-    }
-        // Print the generated Bearer Token to the console
-        fmt.Println(bearerToken);
+You can also set context on `Credentials` for automatic token generation:
 
-    // Approach 2: Generate Bearer Token by specifying the contents of credentials.json as a string
-	// Replace <YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING> with the actual contents of your credentials.json file
-    var fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>";
+```go
+// String context
+creds := common.Credentials{
+    Path:    "path/to/credentials.json",
+    Context: "user_12345",
+}
 
-    // Create a BearerToken object using the file contents as a string
-    res, err = saUtil.GenerateBearerTokenFromCreds(fileContents, common.BearerTokenOptions{LogLevel: logger.DEBUG, Ctx: "<CONTEXT>"})
-
-    if err != nil {
-        fmt.Println("errors:", *err)
-    } else {
-        // Retrieve the Bearer Token as a string
-        bearerToken = res.AccessToken
-        // Print the generated Bearer Token to the console
-        fmt.Println("Token", res.AccessToken)
-    }
-    // Handle exceptions specific to Skyflow operations
-    fmt.Println(bearerToken);
+// Map context
+creds := common.Credentials{
+    Path: "path/to/credentials.json",
+    Context: map[string]interface{}{
+        "role":       "admin",
+        "department": "finance",
+    },
 }
 ```
+
+Context map keys must contain only alphanumeric characters and underscores (`[a-zA-Z0-9_]`). Invalid keys will return a `SkyflowError`.
+
+[Full example](https://github.com/skyflowapi/skyflow-go/blob/v2/samples/v2/serviceaccount/token_generation_with_context.go)
+
+See Skyflow's [context-aware authorization](https://docs.skyflow.com) and [conditional data access](https://docs.skyflow.com) docs for policy variable syntax like `request.context.*`.
 
 ### Generate scoped bearer tokens
 A service account with multiple roles can generate bearer tokens with access limited to a specific role by specifying the appropriate `roleID`. It can be used to limit access to specific roles for services with multiple responsibilities, such as segregating access for billing vs. analytics. The generated bearer tokens are valid for 60 minutes and can only execute operations permitted by the permissions associated with the designated role.

--- a/samples/v2/serviceaccount/token_generation_with_context.go
+++ b/samples/v2/serviceaccount/token_generation_with_context.go
@@ -13,31 +13,57 @@ import (
 
 /**
  * Example program to generate a Bearer Token with context.
- * The token can be generated in two ways:
- * 1. Using the file path to a credentials.json file.
- * 2. Using the stringify JSON content of the credential file.
+ * The token can be generated in three ways:
+ * 1. Using a string context identifier.
+ * 2. Using a JSON object context (map) for conditional data access policies.
+ * 3. Using credentials as a string with context.
  */
 
 func ExampleTokenGenerationWithContext() {
-	// Generate bearer token using file path
 	var filePath = "<FILE_PATH>"
-	res, err := serviceaccount.GenerateBearerToken(filePath, common.BearerTokenOptions{LogLevel: logger.DEBUG, Ctx: "<CONTEXT>"})
+
+	// Approach 1: Bearer token with string context
+	// Use a simple string identifier when your policy references a single context value.
+	res, err := serviceaccount.GenerateBearerToken(filePath, common.BearerTokenOptions{
+		LogLevel: logger.DEBUG,
+		Ctx:      "user_12345",
+	})
 	if err != nil {
 		fmt.Println("errors", *err)
 	} else {
-		fmt.Println("Token", res.AccessToken)
-
+		fmt.Println("Token (string context):", res.AccessToken)
 	}
-	// Generate bearer token using cred as string
-	var credString = "<CRED_STRING>"
-	res1, err1 := serviceaccount.GenerateBearerTokenFromCreds(credString, common.BearerTokenOptions{LogLevel: logger.DEBUG, Ctx: "<CONTEXT>"})
-	if err1 != nil {
-		fmt.Println("errors", *err1)
+
+	// Approach 2: Bearer token with JSON object context
+	// Use a map when your policy needs multiple context values for conditional data access.
+	// Each key maps to a Skyflow CEL policy variable under request.context.*
+	// For example: request.context.role == "admin" && request.context.department == "finance"
+	ctxMap := map[string]interface{}{
+		"role":       "admin",
+		"department": "finance",
+		"user_id":    "user_12345",
+	}
+	res2, err2 := serviceaccount.GenerateBearerToken(filePath, common.BearerTokenOptions{
+		LogLevel: logger.DEBUG,
+		Ctx:      ctxMap,
+	})
+	if err2 != nil {
+		fmt.Println("errors", *err2)
 	} else {
-		fmt.Println("Token", res1.AccessToken)
-
+		fmt.Println("Token (object context):", res2.AccessToken)
 	}
 
+	// Approach 3: Bearer token from credentials string with context
+	var credString = "<CRED_STRING>"
+	res3, err3 := serviceaccount.GenerateBearerTokenFromCreds(credString, common.BearerTokenOptions{
+		LogLevel: logger.DEBUG,
+		Ctx:      "user_12345",
+	})
+	if err3 != nil {
+		fmt.Println("errors", *err3)
+	} else {
+		fmt.Println("Token (creds string):", res3.AccessToken)
+	}
 }
 
 func main() {

--- a/v2/internal/helpers/helpers.go
+++ b/v2/internal/helpers/helpers.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"runtime"
 	"time"
 
@@ -358,6 +359,11 @@ func GetCredentialParams(credKeys map[string]interface{}) (string, string, strin
 
 // Generate signed tokens
 func GenerateSignedDataTokensHelper(clientID, keyID string, pvtKey *rsa.PrivateKey, options common.SignedDataTokensOptions, tokenURI string) ([]common.SignedDataTokensResponse, *skyflowError.SkyflowError) {
+	resolvedCtx, ctxErr := ValidateAndResolveCtx(options.Ctx)
+	if ctxErr != nil {
+		return nil, ctxErr
+	}
+
 	var responseArray []common.SignedDataTokensResponse
 	for _, token := range options.DataTokens {
 		claims := jwt.MapClaims{
@@ -373,8 +379,8 @@ func GenerateSignedDataTokensHelper(clientID, keyID string, pvtKey *rsa.PrivateK
 		} else {
 			claims["exp"] = time.Now().Add(time.Duration(60) * time.Second).Unix()
 		}
-		if options.Ctx != "" {
-			claims["ctx"] = options.Ctx
+		if resolvedCtx != nil {
+			claims["ctx"] = resolvedCtx
 		}
 
 		tokenString, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(pvtKey)
@@ -509,7 +515,41 @@ func GetBaseURL(urlStr string) (string, *skyflowError.SkyflowError) {
 	baseURL := fmt.Sprintf("%s://%s", parsedUrl.Scheme, parsedUrl.Host)
 	return baseURL, nil
 }
+// ValidateAndResolveCtx validates the ctx value and returns the resolved value for JWT claims.
+// Returns (nil, nil) if ctx should be omitted, (value, nil) if valid, or (nil, error) if invalid.
+var ctxKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
+func ValidateAndResolveCtx(ctx interface{}) (interface{}, *skyflowError.SkyflowError) {
+	if ctx == nil {
+		return nil, nil
+	}
+	switch v := ctx.(type) {
+	case string:
+		if v == "" {
+			return nil, nil
+		}
+		return v, nil
+	case map[string]interface{}:
+		if len(v) == 0 {
+			return nil, nil
+		}
+		for key := range v {
+			if !ctxKeyPattern.MatchString(key) {
+				return nil, skyflowError.NewSkyflowError(skyflowError.INVALID_INPUT_CODE,
+					fmt.Sprintf(skyflowError.INVALID_CTX_MAP_KEY, key))
+			}
+		}
+		return v, nil
+	default:
+		return nil, skyflowError.NewSkyflowError(skyflowError.INVALID_INPUT_CODE, skyflowError.INVALID_CTX_TYPE)
+	}
+}
+
 func GetSignedBearerUserToken(clientID, keyID, tokenURI string, pvtKey *rsa.PrivateKey, options common.BearerTokenOptions) (string, *skyflowError.SkyflowError) {
+	resolvedCtx, ctxErr := ValidateAndResolveCtx(options.Ctx)
+	if ctxErr != nil {
+		return "", ctxErr
+	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
 		"iss": clientID,
@@ -518,8 +558,8 @@ func GetSignedBearerUserToken(clientID, keyID, tokenURI string, pvtKey *rsa.Priv
 		"sub": clientID,
 		"exp": time.Now().Add(60 * time.Minute).Unix(),
 	})
-	if options.Ctx != "" {
-		token.Claims.(jwt.MapClaims)["ctx"] = options.Ctx
+	if resolvedCtx != nil {
+		token.Claims.(jwt.MapClaims)["ctx"] = resolvedCtx
 	}
 	var err error
 	signedToken, err := token.SignedString(pvtKey)

--- a/v2/internal/vault/controller/vault_controller.go
+++ b/v2/internal/vault/controller/vault_controller.go
@@ -39,7 +39,7 @@ func GenerateToken(credentials common.Credentials) (*string, *skyflowError.Skyfl
 	if credentials.Roles != nil {
 		options.RoleIDs = credentials.Roles
 	}
-	if credentials.Context != "" {
+	if credentials.Context != nil {
 		options.Ctx = credentials.Context
 	}
 	switch {

--- a/v2/utils/common/common.go
+++ b/v2/utils/common/common.go
@@ -164,7 +164,7 @@ const (
 )
 
 type BearerTokenOptions struct {
-	Ctx      string
+	Ctx      interface{}
 	RoleIDs  []string
 	LogLevel logger.LogLevel
 }
@@ -172,7 +172,7 @@ type BearerTokenOptions struct {
 type SignedDataTokensOptions struct {
 	DataTokens []string
 	TimeToLive int
-	Ctx        string
+	Ctx        interface{}
 	LogLevel   logger.LogLevel
 }
 
@@ -192,7 +192,7 @@ type VaultConfig struct {
 type Credentials struct {
 	Path              string
 	Roles             []string
-	Context           string
+	Context           interface{}
 	CredentialsString string
 	Token             string
 	ApiKey            string

--- a/v2/utils/error/message.go
+++ b/v2/utils/error/message.go
@@ -127,4 +127,7 @@ const (
 	INVALID_BASE64                                           = internal.SDK_PREFIX + " Validation error. Invalid base64 string in file upload request. Specify a valid base64 string."
 	INVALID_FILE_PATH                                       = internal.SDK_PREFIX + " Validation error. The file path is invalid. Specify a valid file path."
 	EMPTY_COLUMN_NAME                                       = internal.SDK_PREFIX + " Validation error. 'columnName' can't be empty. Specify a column name."
+	EMPTY_CONTEXT                                           = internal.SDK_PREFIX + " Initialization failed. Invalid context. Specify a valid context."
+	INVALID_CTX_TYPE                                        = internal.SDK_PREFIX + " Initialization failed. Invalid ctx type. Specify ctx as a string or a map[string]interface{}."
+	INVALID_CTX_MAP_KEY                                     = internal.SDK_PREFIX + " Initialization failed. Invalid key '%s' in ctx map. Keys must contain only alphanumeric characters and underscores."
 )


### PR DESCRIPTION
## Summary

- Extends bearer token and signed data token generation to accept `map[string]interface{}` for the `Ctx` field, in addition to the existing `string` type
- Enables structured context for conditional data access policies where ctx object keys map to Skyflow CEL policy variables (`request.context.role`, `request.context.department`, etc.)
- Adds `ValidateAndResolveCtx()` helper with key validation (`^[a-zA-Z0-9_]+$` for CEL compatibility)
- golang-jwt/jwt/v4's MapClaims natively serializes `map[string]interface{}` as a JSON object in JWT payload
- Widened `Ctx` fields on `BearerTokenOptions`, `SignedDataTokensOptions`, and `Credentials.Context` to `interface{}`
- New error messages: `INVALID_CTX_TYPE`, `INVALID_CTX_MAP_KEY`, `EMPTY_CONTEXT`
- No test regressions (59 passed / 12 failed — same as main branch)
- Updated README and samples with both string and map ctx patterns

## Test plan

- [x] `go test ./internal/helpers/...` — no regressions vs main (59 pass / 12 pre-existing fail)
- [x] `go test ./serviceaccount/...` — no regressions vs main (14 pass / 3 pre-existing fail)
- [x] `go build ./...` — compiles clean
- [ ] Integration test with Skyflow backend using map ctx in bearer token

Resolves: SK-2680, DOCU-1439

🤖 Generated with [Claude Code](https://claude.com/claude-code)